### PR TITLE
Python 3.x cmp fix

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,6 @@
 *.egg
 *.zip
 *.swp
+
+# PyCharm / IntelliJ projects
+.idea/**

--- a/virtualbox/library_base.py
+++ b/virtualbox/library_base.py
@@ -12,6 +12,8 @@ try:
     import __builtin__ as builtin 
 except:
     import builtins as builtin
+    def cmp(a,b):
+        return (a > b) - (a < b)
 
 
 def pythonic_name(name):

--- a/virtualbox/library_base.py
+++ b/virtualbox/library_base.py
@@ -12,9 +12,6 @@ try:
     import __builtin__ as builtin 
 except:
     import builtins as builtin
-    def cmp(a,b):
-        return (a > b) - (a < b)
-
 
 def pythonic_name(name):
     s1 = re.sub('(.)([A-Z][a-z]+)', r'\1_\2', name)
@@ -82,7 +79,7 @@ class Enum(object):
         return self.__cmp__(k) == 0
 
     def __cmp__(self, k):
-        return cmp(int(self), int(k))
+        return (int(self) > int(k)) - (int(self) < int(k))
 
     def __getitem__(self, k):
         return self.__class__[k]


### PR DESCRIPTION
Hello,

using Python 3.x on Windows, I got the next error while trying out some code:

```
Traceback (most recent call last):
  File "C:/Users/.../virtualboxtest/main.py", line 23, in <module>
    gs = session.console.guest.create_session('...','...')
  File "C:\Python34\lib\site-packages\virtualbox\library_ext\guest.py", line 20, in create_session
    if session.status == library.GuestSessionStatus.started:
  File "C:\Python34\lib\site-packages\virtualbox\library_base.py", line 82, in __eq__
    return self.__cmp__(k) == 0
  File "C:\Python34\lib\site-packages\virtualbox\library_base.py", line 85, in __cmp__
    return cmp(int(self), int(k))
NameError: name 'cmp' is not defined
```
I took the liberty of fixing this by adding the method if the import of the 2.x builtins fails (indicating python 3.x).