### PR TITLE
call "exportTo" instead of "export" in iMachine.export_to(...)

### DIFF
--- a/docs/source/virtualbox/library_ext.rst
+++ b/docs/source/virtualbox/library_ext.rst
@@ -1,7 +1,7 @@
 :mod:`virtualbox.library_ext` -- extensions to *virtualbox.library*
 ===================================================================
 
-.. module:: virualbox.library_ext
+.. module:: virtualbox.library_ext
     :synopsis: pyvbox
 .. moduleauthor:: Michael Dorman <mjdorma+pyvbox@gmail.com>
 .. sectionauthor:: Michael Dorman <mjdorma+pyvbox@gmail.com>

--- a/virtualbox/library_ext/machine.py
+++ b/virtualbox/library_ext/machine.py
@@ -188,7 +188,8 @@ class IMachine(library.IMachine):
             raise TypeError(msg)
         if not isinstance(location, basestring):
             raise TypeError("value is not an instance of basestring")
-        description = self._call("export",
+        # see https://github.com/mjdorma/pyvbox/issues/40
+        description = self._call("exportTo",
                      in_p=[appliance, location])
         description = library.IVirtualSystemDescription(description)
         return description


### PR DESCRIPTION
As described in https://github.com/mjdorma/pyvbox/issues/40, I had to change the call to "export" to "exportTo" to make export_to(...) work with the latest VirtualBox version `5.0.8 r103449`; this fix is possibly required for all `5.x.y` versions and should probably be done conditionally based on the version of the underlying VirtualBox package for backwards compatibility; unfortunately, I don't know how to determine that version...