### PR TITLE
Fix bug where machine pool dosen't work

### DIFF
--- a/virtualbox/pool.py
+++ b/virtualbox/pool.py
@@ -171,7 +171,6 @@ class MachinePool(object):
                     guest_session.close()
                     console.pause()
                     id_p, p = console.machine.take_snapshot('initialised', 'machine pool', True)
-                    #p.wait_for_completion(60*1000)
                     time.sleep(10)
                     self._power_down(session)
                 finally:

--- a/virtualbox/pool.py
+++ b/virtualbox/pool.py
@@ -162,14 +162,14 @@ class MachinePool(object):
                     idle_count = 0
                     timeout = 60
                     while idle_count < 5 and timeout > 0:
-                        act = console.get_device_activity(DeviceType.hard_disk)
-                        if act == DeviceActivity.idle:
+                        act = console.get_device_activity([DeviceType.hard_disk])
+                        if act[0] == DeviceActivity.idle:
                             idle_count += 1
                         time.sleep(0.5)
                         timeout -= 0.5
                     guest_session.close()
                     console.pause()
-                    p = console.take_snapshot('initialised', 'machine pool')
+                    id_p, p = console.machine.take_snapshot('initialised', 'machine pool', True)
                     p.wait_for_completion(60*1000)
                     self._power_down(session)
                 finally:

--- a/virtualbox/pool.py
+++ b/virtualbox/pool.py
@@ -122,7 +122,8 @@ class MachinePool(object):
             session.unlock_machine()
             session = clone.create_session()
             console = session.console
-            p = console.restore_snapshot()
+            console.machine.restore_snapshot()
+            time.sleep(1)
             p.wait_for_completion(60*1000)
             return clone
         finally:
@@ -170,7 +171,8 @@ class MachinePool(object):
                     guest_session.close()
                     console.pause()
                     id_p, p = console.machine.take_snapshot('initialised', 'machine pool', True)
-                    p.wait_for_completion(60*1000)
+                    #p.wait_for_completion(60*1000)
+                    time.sleep(10)
                     self._power_down(session)
                 finally:
                     if session.state == SessionState.locked:


### PR DESCRIPTION
The machine pool uses code that doesn't seem to work with the current version of the library. This should fix it so it is creating snapshots correctly. 