### PR TITLE
Don't print out error arguments on Windows

### DIFF
--- a/virtualbox/library_base.py
+++ b/virtualbox/library_base.py
@@ -189,7 +189,6 @@ class Interface(object):
             errobj.msg = None
             if platform.system() == 'Windows':
                 if hasattr(exc, 'args'):
-                    print(exc.args)
                     errobj.msg = exc.args[2][2]
 	    # TODO: get the Linux/Darwin specific args struct
 


### PR DESCRIPTION
Printing this information is not appropriate as it cannot be disabled or ignored in application code.
It would be quite frustrating if I had to vendor this dependency just to remove a single line.

Also, can we have a new release of this package on PyPI?