### PR TITLE
Search for vboxapi using the root of sys.executable

### DIFF
--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -1,6 +1,12 @@
 Change log
 ==========
 
+master
+
+* Add sys.executable-derived paths in list to check for vboxapi (@SethMichaelLarson PR #69)
+* Fix IGuestProcess.execute() on Python 3.x (@SethMichaelLarson PR #58)
+* Fix errors to not output on Windows platforms. (@SethMichaelLarson PR #57)
+
 version 1.0.0
 
 * Support for 5.0.x VirtualBox.
@@ -10,7 +16,7 @@ version 1.0.0
 
 version 0.2.2
 
-* Cleanup managers at exiti (reported by @jiml521).
+* Cleanup managers at exit (reported by @jiml521).
 * Add three time check for attribute in xpcom interface object before failing (reported
   by @shohamp). 
 * Update library.py to 4.3.28/src/VBox/Main/idl/VirtualBox.xidl

--- a/virtualbox/__init__.py
+++ b/virtualbox/__init__.py
@@ -65,7 +65,23 @@ def import_vboxapi():
             search = ['/Library/Python/%s.%s/site-packages' % py_mm_ver]
         else:
             # No idea where to look...
-            raise
+            search = []
+
+        # Generates a common prefix from sys.executable in the
+        # case that vboxapi is installed in a virtualenv.
+        # This will also help with when we don't know where
+        # to search because of an unknown platform.
+        # These paths also help if the system Python is installed
+        # in a non-standard location.
+        #
+        # NOTE: We don't have to worry if these directories don't
+        # exist as they're checked below.
+        prefix = os.path.dirname(os.path.dirname(sys.executable))
+        search.extend([os.path.join(prefix, 'Lib', 'site-packages'),
+                       os.path.join(prefix, 'Lib', 'site-packages', 'win32'),
+                       os.path.join(prefix, 'Lib', 'site-packages', 'win32', 'lib'),
+                       os.path.join(prefix, 'lib', 'site-packages'),
+                       os.path.join(prefix, 'lib', 'dist-packages')])
 
         packages = set(packages)
         original_path = copy.copy(sys.path)


### PR DESCRIPTION
Fixes #67 Also has the side-effect of allowing us to (potentially?) find the `vboxapi` module on platforms that we previously didn't recognize.