### PR TITLE
Raise more descriptive error with zero-length password.

### DIFF
--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -3,6 +3,8 @@ Change log
 
 master
 
+* IGuest.create_session() now raises a more descriptive error if
+  not able to connect with a zero-length password. (@SethMichaelLarson PR #70)
 * Add sys.executable-derived paths in list to check for vboxapi (@SethMichaelLarson PR #69)
 * Fix IGuestProcess.execute() on Python 3.x (@SethMichaelLarson PR #58)
 * Fix errors to not output on Windows platforms. (@SethMichaelLarson PR #57)

--- a/virtualbox/library_ext/guest.py
+++ b/virtualbox/library_ext/guest.py
@@ -21,6 +21,9 @@ class IGuest(library.IGuest):
                 break
             time.sleep(0.1)
         else:
+            if len(password) == 0:
+                raise SystemError('GuestSession failed to start. Could be because '
+                                  'of using an empty password.')
             raise SystemError("GuestSession failed to start")
         if timeout_ms != 0:
             # There is probably a better way to to this?


### PR DESCRIPTION
Because this has happened to more than one person I figured it would be a good idea to have a more descriptive error message for this situation. Fixes #62