### PR TITLE
Fix error when using setattr on COM interface with Enum.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -8,6 +8,8 @@ master
 * Add sys.executable-derived paths in list to check for vboxapi (@SethMichaelLarson PR #69)
 * Fix IGuestProcess.execute() on Python 3.x (@SethMichaelLarson PR #58)
 * Fix errors to not output on Windows platforms. (@SethMichaelLarson PR #57)
+* Fix error caused by attempting to set any attribute in the COM interface
+  using setattr raising an error. (Reported by @josepegerent, patch by @SethMichaelLarson PR #74)
 
 version 1.0.0
 

--- a/virtualbox/library_base.py
+++ b/virtualbox/library_base.py
@@ -164,6 +164,8 @@ class Interface(object):
         if inspect.isfunction(attr) or inspect.ismethod(attr):
             return self._call_method(attr, value)
         else:
+            if isinstance(value, Enum):
+                value = int(value)
             return setattr(self._i, name, value)
 
     def _call(self, name, in_p=None):


### PR DESCRIPTION
This should fix #73 and this is definitely a good time for a new release.
I am quite surprised that this bug went unnoticed for so long, better now than never!

This works on my machine perfectly and fixes the problem which occurred in more than one place. Can you verify that this also works in your case @josepegerent ?

I can prepare the release tomorrow if you'd like @mjdorma, just need you to do the committing to PyPI. :)